### PR TITLE
Add support for loading old jmeslog formats

### DIFF
--- a/.changes/next-release/22911366940-feature-oldformat-36389.json
+++ b/.changes/next-release/22911366940-feature-oldformat-36389.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "old-format",
+  "description": "Add support for loading old jmeslog formats."
+}

--- a/tests/test_jmeslog.py
+++ b/tests/test_jmeslog.py
@@ -284,10 +284,38 @@ def test_can_consolidate_next_release(tmpdir):
     with open(str(change_dir.join('1.1.0.json'))) as f:
         data = json.load(f)
     assert data == {
-        'schema-version': '1.0',
+        'schema-version': '0.2',
         'changes': [
             {'type': 'feature', 'category': 'foo', 'description': 'bar'},
             {'type': 'bugfix', 'category': 'foo', 'description': 'bar'},
             {'type': 'enhancement', 'category': 'foo', 'description': 'bar'},
         ]
     }
+
+
+def test_can_create_collection_from_dict():
+    release_data = {
+        'schema-version': '0.2',
+        'changes': [
+            {'type': 'feature', 'category': 'foo', 'description': 'bar'},
+        ],
+        'summary': 'Foo release.'
+    }
+    collection = jmeslog.JMESLogEntryCollection.from_dict(release_data)
+    assert collection.schema_version == '0.2'
+    assert collection.summary == 'Foo release.'
+    assert collection.changes == [jmeslog.JMESLogEntry(type='feature',
+                                                       category='foo',
+                                                       description='bar')]
+
+
+def test_can_create_collection_from_old_format():
+    release_data = [
+        {'type': 'feature', 'category': 'foo', 'description': 'bar'},
+    ]
+    collection = jmeslog.JMESLogEntryCollection.from_dict(release_data)
+    assert collection.schema_version == '0.1'
+    assert collection.summary == ''
+    assert collection.changes == [jmeslog.JMESLogEntry(type='feature',
+                                                       category='foo',
+                                                       description='bar')]


### PR DESCRIPTION
This is used by several projects such as the AWS CLI, boto3, etc.

The main issue is that these existing projects use a list of their `x.y.z.json` files, e.g:

```
[
  {
    "category": "shorthand", 
    "description": "The CLI now no longer allows a key to be spcified twice in a shorthand parameter. For example foo=bar,foo=baz would previously be accepted, with only baz being set, and foo=bar silently being ignored. Now an error will be raised pointing out the issue, and suggesting a fix.", 
    "type": "enhancement"
  }
]
```

Having this be a list is problematic because it doesn't allow you to have additional metadata (key/val pairs) for the release itself.  For example, in Chalice there's sometimes a `summary` for a release (https://github.com/aws/chalice/blob/master/CHANGELOG.rst#100b2).

This change allows jmeslog to load both formats.  If the older list format is used, then we just have an empty summary.

cc @stealthycoin